### PR TITLE
fix: css missing from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN python -m playwright install chromium
 COPY main.py /app/
 COPY templates /app/templates
 COPY helpers /app/helpers
+COPY static /app/static
 
 # Expose the Flask port
 EXPOSE 9001


### PR DESCRIPTION
Hey @JoTec2002, I forgot to add the CSS files in the Dockerfile in my last PR (#12), so here is another PR fixing that.

Sorry for that, I just tried the latest version you pushed to Docker Hub (v1.4.1) and noticed it was missing the CSS.