### PR TITLE
fix: avoid swallowing exception

### DIFF
--- a/helpers/instadownloader.py
+++ b/helpers/instadownloader.py
@@ -91,3 +91,4 @@ class InstaDownloader:
             return post
         except Exception as e:
             print(f"Error downloading post: {e}")
+            raise e


### PR DESCRIPTION
Currently, if instaloader fails to download a post, the resulting error message is "AttributeError: 'NoneType' object has no attribute 'shortcode'" on main.py#L21 This commit raises the raw exception from instaloader directly rather than swallowing it, to provide useful information in the logs.